### PR TITLE
Added ability to dynamically switch drive type for e.g., from Arcade Drive to Tank Drive etc.

### DIFF
--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -88,7 +88,7 @@ public class Robot extends TimedRobot {
       m_chooser.setDefaultOption(Constants.ARCADE_DRIVE, Constants.ARCADE_DRIVE);
       m_chooser.addOption(Constants.TANK_DRIVE, Constants.TANK_DRIVE);
       m_chooser.addOption(Constants.CURVATURE_DRIVE, Constants.CURVATURE_DRIVE);
-      SmartDashboard.putData("Drive Modes: ", m_chooser);
+      SmartDashboard.putData("Drive Choices: ", m_chooser);
 
       m_ballTracker = new BallTracker();
       //Initializes the encoders. 
@@ -179,18 +179,15 @@ public class Robot extends TimedRobot {
   public void teleopPeriodic() {
     try {
       logger.logInfo("Teleop periodic started");
-      if ((m_logCounter / 100.0) % 1 == 0) {
-        if (m_ballTracker.chooseMostConfidentBall() != null) {
-          logger.logInfo(m_ballTracker.chooseMostConfidentBall().toString());
-        }
-        else {
-          logger.logInfo("No ball located!");
-        }
+      if (m_ballTracker.chooseMostConfidentBall() != null) {
+        SmartDashboard.putString("Most confident ball: ", m_ballTracker.chooseMostConfidentBall().toString());
       }
-      // //Set up arcade steer
-      // double forward = -driverController.getRawAxis(2);
-      // double turn = -driverController.getRawAxis(1);
+      else {
+        SmartDashboard.putString("Most confident ball: ", "No ball located!");
+      }
+
       m_driveMode = m_chooser.getSelected();
+      m_robotContainer.setDriveType(m_driveMode);
 
       //Intake controls
       if(driverController.getRawButton(5)){

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -44,19 +44,7 @@ public class RobotContainer {
   /** The container for the robot. Contains subsystems, OI devices, and commands. */
   public RobotContainer() {
     // assign default commands
-    switch(m_driveType) {
-      case ARCADE_DRIVE:
-        m_drivetrain.setDefaultCommand(new ArcadeDrive(() -> (-m_driverStick.getRawAxis(Constants.JOYSTICK_LEFT_Y)), () -> m_driverStick.getRawAxis(Constants.JOYSTICK_RIGHT_X), m_drivetrain, Constants.JOYSTICK_THROTTLESPEED)); 
-        break;
-      case TANK_DRIVE:
-        m_drivetrain.setDefaultCommand(new TankDrive(() -> (-m_driverStick.getRawAxis(Constants.JOYSTICK_LEFT_Y)), () -> m_driverStick.getRawAxis(Constants.JOYSTICK_RIGHT_X), m_drivetrain));
-        break;
-      case CURVATURE_DRIVE:
-        m_drivetrain.setDefaultCommand(new CurvatureDrive(() -> (-m_driverStick.getRawAxis(Constants.JOYSTICK_LEFT_Y)), () -> m_driverStick.getRawAxis(Constants.JOYSTICK_RIGHT_X), m_isQuickTurn, m_drivetrain));
-        break;
-      default:
-        m_drivetrain.setDefaultCommand(new ArcadeDrive(() -> (-m_driverStick.getRawAxis(Constants.JOYSTICK_LEFT_Y)), () -> m_driverStick.getRawAxis(Constants.JOYSTICK_RIGHT_X), m_drivetrain, Constants.JOYSTICK_THROTTLESPEED));
-    }
+    m_drivetrain.setDefaultCommand(new ArcadeDrive(() -> (-m_driverStick.getRawAxis(Constants.JOYSTICK_LEFT_Y)), () -> m_driverStick.getRawAxis(Constants.JOYSTICK_RIGHT_X), m_drivetrain, Constants.JOYSTICK_THROTTLESPEED));
     
     // Configure the button bindings
     configureButtonBindings();
@@ -84,15 +72,6 @@ public class RobotContainer {
 
   public Command getTeleopCommand(){
     return m_teleopCommand;
-  }
-
-  public void setDriveType(String driveType) {
-    if("Tank Drive".equalsIgnoreCase(driveType)) {  
-      m_driveType = DriveType.TANK_DRIVE;
-    }
-    else {
-      m_driveType = DriveType.ARCADE_DRIVE;
-    }
   }
 
   /**
@@ -129,4 +108,38 @@ public class RobotContainer {
   public DriveTrain getDriveTrain() {
     return m_drivetrain;
   }
-} 
+
+   public void checkDrivetype() {
+    switch(m_driveType) {
+      case ARCADE_DRIVE:
+        m_drivetrain.setDefaultCommand(new ArcadeDrive(() -> (-m_driverStick.getRawAxis(Constants.JOYSTICK_LEFT_Y)), () -> m_driverStick.getRawAxis(Constants.JOYSTICK_RIGHT_X), m_drivetrain, Constants.JOYSTICK_THROTTLESPEED)); 
+        break;
+      case TANK_DRIVE:
+        m_drivetrain.setDefaultCommand(new TankDrive(() -> (-m_driverStick.getRawAxis(Constants.JOYSTICK_LEFT_Y)), () -> m_driverStick.getRawAxis(Constants.JOYSTICK_RIGHT_X), m_drivetrain));
+        break;
+      case CURVATURE_DRIVE:
+        m_drivetrain.setDefaultCommand(new CurvatureDrive(() -> (-m_driverStick.getRawAxis(Constants.JOYSTICK_LEFT_Y)), () -> m_driverStick.getRawAxis(Constants.JOYSTICK_RIGHT_X), m_isQuickTurn, m_drivetrain));
+        break;
+      default:
+        m_drivetrain.setDefaultCommand(new ArcadeDrive(() -> (-m_driverStick.getRawAxis(Constants.JOYSTICK_LEFT_Y)), () -> m_driverStick.getRawAxis(Constants.JOYSTICK_RIGHT_X), m_drivetrain, Constants.JOYSTICK_THROTTLESPEED)); 
+    }
+  }
+
+  /**
+   * Sets the drive type based on the string passed in (called in after getting SendableChooser in Robot.java)
+   * Also runs the checkDriveType() method, to change the drivetype if necessary.
+   */ 
+  public void setDriveType(String driveType) {
+    if(Constants.TANK_DRIVE.equalsIgnoreCase(driveType)) {  
+      m_driveType = DriveType.TANK_DRIVE;
+    }
+    else if(Constants.CURVATURE_DRIVE.equalsIgnoreCase(driveType)) {
+      m_driveType = DriveType.CURVATURE_DRIVE;
+    }
+    else {
+      m_driveType = DriveType.ARCADE_DRIVE;
+    }
+
+    checkDrivetype();
+  }
+ } 

--- a/src/main/java/frc/robot/auto/BallTracker.java
+++ b/src/main/java/frc/robot/auto/BallTracker.java
@@ -8,6 +8,7 @@ import edu.wpi.first.networktables.NetworkTable;
 import edu.wpi.first.networktables.NetworkTableInstance;
 import frc.robot.logging.RobotLogger;
 import frc.robot.RobotContainer;
+import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 
 
 public class BallTracker {
@@ -32,7 +33,7 @@ public class BallTracker {
         String networkTableEntryAsString = m_ballDataTable.getEntry("detections").getString(null);
 
         if (networkTableEntryAsString == null) {
-            logger.logError("Image Coordinate Table entry is null");
+            SmartDashboard.putString("Ball Data status: ", "Image Coordinate Table entry is null");
             return null;
         }
         JSONArray jsonArray = new JSONArray(networkTableEntryAsString);


### PR DESCRIPTION
Though existing previously with arcade drive, tank and curvature drives, the actual switching did not work. It would remain arcade drive though having switched the option on smartdashboard. 

--> Added periodic checking of drivetype value and switching if needed.
--> MUST PRESS RIGHT TRIGGER to initiate a change after changing on smartdashboard.
  Has been tested on old 2020 hardware.

This is the fixed, without conflict version of PR #10 , from dg--drivemode-chooser. 